### PR TITLE
Add 'lookback_minutes' to the config json to ensure we don't miss any ticket audits

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-zendesk',
-      version='1.4.26',
+      version='1.4.27',
       description='Singer.io tap for extracting data from the Zendesk API',
       author='Stitch',
       url='https://singer.io',

--- a/tap_zendesk/sync.py
+++ b/tap_zendesk/sync.py
@@ -15,7 +15,7 @@ def process_record(record):
     rec_dict = json.loads(rec_str)
     return rec_dict
 
-def sync_stream(state, start_date, instance):
+def sync_stream(state, start_date, instance, lookback_minutes):
     stream = instance.stream
 
     # If we have a bookmark, use it; otherwise use start_date
@@ -28,7 +28,8 @@ def sync_stream(state, start_date, instance):
 
     parent_stream = stream
     with metrics.record_counter(stream.tap_stream_id) as counter:
-        for (stream, record) in instance.sync(state):
+        for (stream, record) in instance.sync(state) if instance.name != 'ticket_audits' \
+                else instance.sync(state, lookback_minutes):
             # NB: Only count parent records in the case of sub-streams
             if stream.tap_stream_id == parent_stream.tap_stream_id:
                 counter.increment()

--- a/tap_zendesk/sync.py
+++ b/tap_zendesk/sync.py
@@ -28,8 +28,9 @@ def sync_stream(state, start_date, instance, lookback_minutes):
 
     parent_stream = stream
     with metrics.record_counter(stream.tap_stream_id) as counter:
-        for (stream, record) in instance.sync(state) if instance.name != 'ticket_audits' \
-                else instance.sync(state, lookback_minutes):
+        to_process = instance.sync(state) if instance.name != 'ticket_audits' \
+            else instance.sync(state, lookback_minutes)
+        for (stream, record) in to_process:
             # NB: Only count parent records in the case of sub-streams
             if stream.tap_stream_id == parent_stream.tap_stream_id:
                 counter.increment()


### PR DESCRIPTION
Ensures we don't miss any ticket audits, configurable per TapConfig/customer. 