### PR TITLE
Users stream limited to admins and agents

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-zendesk',
-      version='1.4.28',
+      version='1.4.29',
       description='Singer.io tap for extracting data from the Zendesk API',
       author='Stitch',
       url='https://singer.io',

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -169,8 +169,8 @@ class Organizations(Stream):
 
 class Users(Stream):
     name = "users"
-    replication_method = "INCREMENTAL"
-    replication_key = "updated_at"
+    replication_method = "FULL_TABLE"
+    key_properties = ["id"]
 
     def _add_custom_fields(self, schema):
         try:
@@ -184,10 +184,9 @@ class Users(Stream):
         return schema
 
     def sync(self, state):
-        bookmark = self.get_bookmark(state)
-        users = self.client.users.incremental(start_time=bookmark)
+        LOGGER.info('STARTING TO SYNC USERSSSS')
+        users = self.client.users(role=['agent', 'admin'])
         for user in users:
-            self.update_bookmark(state, user.updated_at)
             yield (self.stream, user)
 
 class Tickets(Stream):

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -184,7 +184,6 @@ class Users(Stream):
         return schema
 
     def sync(self, state):
-        LOGGER.info('STARTING TO SYNC USERSSSS')
         users = self.client.users(role=['agent', 'admin'])
         for user in users:
             yield (self.stream, user)


### PR DESCRIPTION
Kogan has a custom field that checks who was the last agent to comment on on a ticket. Since comment authors can also be end-users, we need a table of agent ID's. I was wary of storing customers' end users' data (and we shouldn't ever need to), I've updated this stream to limit to just agents & admins. 