### PR TITLE
Update incremental satisfaction ratings stream

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-zendesk',
-      version='1.4.29',
+      version='1.4.30',
       description='Singer.io tap for extracting data from the Zendesk API',
       author='Stitch',
       url='https://singer.io',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-zendesk',
-      version='1.4.28',
+      version='1.4.29',
       description='Singer.io tap for extracting data from the Zendesk API',
       author='Stitch',
       url='https://singer.io',


### PR DESCRIPTION
Only grabs satisfaction ratings for the dates we need, speeding up the tap (grabbed from https://github.com/singer-io/tap-zendesk/blob/master/tap_zendesk/streams.py) 