### PR TITLE
INF-435: Respect bookmark for ticket metric events

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-zendesk',
-      version='1.5.7',
+      version='1.5.8',
       description='Singer.io tap for extracting data from the Zendesk API',
       author='Stitch',
       url='https://singer.io',

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -403,6 +403,7 @@ class TicketMetricEvents(Stream):
     name = "ticket_metric_events"
     replication_method = "INCREMENTAL"
     key_properties = ['id']
+    replication_key = 'time'
 
     def sync(self, state):
         bookmark = self.get_bookmark(state)

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -91,13 +91,27 @@ class Stream():
                 yield rec
             self.buf[stream_name] = []
 
+    def _get_bookmark_key(self, log: bool=False) -> str:
+        bookmark_key = self.replication_key
+        if self.replication_key is None:
+            # When we serialize None to json, it turns into 'null'. However, when we deserialize the
+            # state, the key to search for is 'null' and not None. This means that it will always use the start date
+            # since the key is never found.
+            bookmark_key = 'null'
+            if log:
+                LOGGER.warning(f'no replication key set for {self.name}, bookmark key set to "{bookmark_key}"')
+        return bookmark_key
+
     def get_bookmark(self, state):
-        return utils.strptime_with_tz(singer.get_bookmark(state, self.name, self.replication_key))
+        bookmark_key = self._get_bookmark_key()
+        state_bookmark = singer.get_bookmark(state, self.name, bookmark_key)
+        return utils.strptime_with_tz(state_bookmark)
 
     def update_bookmark(self, state, value):
         current_bookmark = self.get_bookmark(state)
+        bookmark_key = self._get_bookmark_key()
         if value and utils.strptime_with_tz(value) > current_bookmark:
-            singer.write_bookmark(state, self.name, self.replication_key, value)
+            singer.write_bookmark(state, self.name, bookmark_key, value)
 
     def load_schema(self):
         schema_file = "schemas/{}.json".format(self.name)

--- a/tap_zendesk/sync.py
+++ b/tap_zendesk/sync.py
@@ -20,12 +20,13 @@ def sync_stream(state, instance):
     start_date = instance.config['start_date']
     lookback_minutes = instance.config.get('lookback_minutes')
 
-    # If we have a bookmark, use it; otherwise use start_date
+    # If we have a bookmark, use it; otherwise set a temp bookmark as the start_date and use that
+    bookmark_key = instance._get_bookmark_key(log=True)
     if (instance.replication_method == 'INCREMENTAL' and
-            not state.get('bookmarks', {}).get(stream.tap_stream_id, {}).get(instance.replication_key)):
+            not state.get('bookmarks', {}).get(stream.tap_stream_id, {}).get(bookmark_key)):
         singer.write_bookmark(state,
                               stream.tap_stream_id,
-                              instance.replication_key,
+                              bookmark_key,
                               start_date)
 
     parent_stream = stream


### PR DESCRIPTION
https://pathlighthq.atlassian.net/browse/INF-435

The state that gets written looks like this:
```
{
    "bookmarks": {
        ...
        "ticket_metric_events": {
            "null": "2022-10-31T00:50:50Z" // note that the key here is null
        }
    }
}

```

However, when we try to get the bookmark, the key to search is 'null' instead of None because of state serialization to json. Thus, it never respects the bookmark and will always use the start_date. We now log a warning if the replication key is unset and will appropriately search for the 'null' key instead of None. So even though when we create a new stream and it's missing a replication key, it'll still respect the bookmark.

We also change the TicketMetricEvents to have a replication key which it was missing before so it's no longer null.